### PR TITLE
Using standard Role-Type for new claim.

### DIFF
--- a/src/KK.AspNetCore.EasyAuthAuthentication/AuthenticationTicketBuilder.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/AuthenticationTicketBuilder.cs
@@ -23,7 +23,7 @@ namespace KK.AspNetCore.EasyAuthAuthentication
                             CreateClaims(claimsPayload, options),
                             AuthenticationTypesNames.Federation,
                             options.NameClaimType,
-                            options.RoleClaimType
+                            ClaimTypes.Role
                         );
             AddScopeClaim(identity);
             AddProviderNameClaim(identity, providerName);


### PR DESCRIPTION
Maybe this is only a dirt fix, but actually if you use AppRoles in the AppRegistration's manifest in MCD, it would generate "roles"-Claims, not ClaimTypes.Role-Claims. Therefor you have to configure EasyAuth at Startup with options.RoleClaimType = "roles". If this type would be used for creating the Claims for the ClaimsPrincipal, it wouldn't automatically the roles for the AuthorizeAttribute (like Authorize(Roles = "Adminstrator"]).